### PR TITLE
Standardized JSON error responses

### DIFF
--- a/app/handlers/api/applications.go
+++ b/app/handlers/api/applications.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/generationtux/brizo/app/handlers/jsonutil"
 	"github.com/generationtux/brizo/database"
 	"github.com/generationtux/brizo/resources"
 	"github.com/go-zoo/bone"
@@ -16,13 +17,19 @@ func ApplicationIndex(w http.ResponseWriter, r *http.Request) {
 	defer db.Close()
 	if err != nil {
 		log.Printf("Database error: '%s'\n", err)
-		http.Error(w, "there was an error when attempting to connect to the database", http.StatusInternalServerError)
+		jre := jsonutil.NewJSONResponseError(
+			http.StatusInternalServerError,
+			"there was an error when attempting to connect to the database")
+		jsonutil.RespondJSONError(w, jre)
 		return
 	}
 	apps, err := resources.AllApplications(db)
 	if err != nil {
 		log.Printf("Error when retrieving applications: '%s'\n", err)
-		http.Error(w, "there was an error when retrieving applications", http.StatusInternalServerError)
+		jre := jsonutil.NewJSONResponseError(
+			http.StatusInternalServerError,
+			"there was an error when attempting to connect to the database")
+		jsonutil.RespondJSONError(w, jre)
 		return
 	}
 	for i := range apps {
@@ -39,7 +46,10 @@ func ApplicationShow(w http.ResponseWriter, r *http.Request) {
 	defer db.Close()
 	if err != nil {
 		log.Printf("Database error: '%s'\n", err)
-		http.Error(w, "there was an error when attempting to connect to the database", http.StatusInternalServerError)
+		jre := jsonutil.NewJSONResponseError(
+			http.StatusInternalServerError,
+			"there was an error when attempting to connect to the database")
+		jsonutil.RespondJSONError(w, jre)
 		return
 	}
 
@@ -47,7 +57,10 @@ func ApplicationShow(w http.ResponseWriter, r *http.Request) {
 	app, err := resources.GetApplication(db, id, resources.GetApplicationPods)
 	if err != nil {
 		log.Printf("Error when retrieving application: '%s'\n", err)
-		http.Error(w, "there was an error when retrieving application", http.StatusInternalServerError)
+		jre := jsonutil.NewJSONResponseError(
+			http.StatusInternalServerError,
+			"there was an error when retrieving application")
+		jsonutil.RespondJSONError(w, jre)
 		return
 	}
 

--- a/app/handlers/api/auth.go
+++ b/app/handlers/api/auth.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/generationtux/brizo/app/handlers/jsonutil"
 	"github.com/generationtux/brizo/auth"
 	"github.com/generationtux/brizo/database"
 	"github.com/mholt/binding"
@@ -20,7 +21,10 @@ func AuthCreateUser(w http.ResponseWriter, r *http.Request) {
 	defer db.Close()
 	if err != nil {
 		log.Printf("Database error: '%s'\n", err)
-		http.Error(w, "there was an error when attempting to connect to the database", http.StatusInternalServerError)
+		jre := jsonutil.NewJSONResponseError(
+			http.StatusInternalServerError,
+			"there was an error when attempting to connect to the database")
+		jsonutil.RespondJSONError(w, jre)
 		return
 	}
 	user := auth.User{
@@ -31,10 +35,14 @@ func AuthCreateUser(w http.ResponseWriter, r *http.Request) {
 	if success == false {
 		log.Printf("%s when trying to create user\n", err)
 		// @todo correctly redirect w/ bad request shown
-		http.Error(w, "there was an error when attemping to create a new user", http.StatusBadRequest)
-	} else {
-		w.WriteHeader(http.StatusCreated)
+		jre := jsonutil.NewJSONResponseError(
+			http.StatusBadRequest,
+			"there was an error when attemping to create a new user")
+		jsonutil.RespondJSONError(w, jre)
+		return
 	}
+	w.WriteHeader(http.StatusCreated)
+	return
 }
 
 // ValidateToken validates the provided JWT token

--- a/app/handlers/jsonutil/json.go
+++ b/app/handlers/jsonutil/json.go
@@ -1,0 +1,106 @@
+// Package jsonutil provides support functions for dealing with json responses
+// and specificially focuses on handling errors.
+package jsonutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ResponseError holds details and a status code related to a specific error.
+type ResponseError struct {
+	Details string `json:"details"`
+	Status  int    `json:"status,string"`
+}
+
+// ResponseErrorBag handles the management and usage of ResponseErrors. It is
+// also responsible for maintaining a high-level status code, which expected to
+// be reflected in the response header.
+type ResponseErrorBag interface {
+	// AddError will create and add a new ResponseError into this ResponseErrorBag
+	// instance. It also accepts an optional status code specific to the error, or
+	// defaults to the ResponseErrorBag's high-level status code.
+	AddError(details string, status ...int) *ResponseErrorBag
+	Errors() []ResponseError
+	Render() string
+	Status() int
+}
+
+// JSONResponseError implements a JSON specific ResponseErrorBag.
+type JSONResponseError struct {
+	bag    []ResponseError
+	Output string
+	status int
+}
+
+// NewJSONResponseError creates a new instance of a JSONResponseError. While a
+// status is required, error messages are optionally added in a shorthand format
+// if desired.
+//     NewJSONResponseError(500)                   // new empty JSONResponseError
+//     NewJSONResponseError(500, "internal error") // new JSONResponseError with single error
+func NewJSONResponseError(status int, messages ...string) *JSONResponseError {
+	jre := JSONResponseError{
+		bag:    make([]ResponseError, 0), // marshals to "[]" instead of null when empty
+		status: status,
+	}
+	if len(messages) > 0 {
+		for _, message := range messages {
+			jre.AddError(message, status)
+		}
+	}
+	return &jre
+}
+
+// Errors acts as a getter to provide a slice of all of the ResponseErrors.
+func (jre *JSONResponseError) Errors() []ResponseError {
+	return jre.bag
+}
+
+// Status acts as a getter to provide the high-level status.
+func (jre *JSONResponseError) Status() int {
+	return jre.status
+}
+
+// AddError adds a new ResponseError, while accepting an optional status code
+// specific to the new ResponseError.
+func (jre *JSONResponseError) AddError(details string, status ...int) *JSONResponseError {
+	var derivedStatus int
+	if len(status) >= 1 {
+		derivedStatus = status[0]
+	} else {
+		derivedStatus = jre.Status()
+	}
+	jre.bag = append(jre.bag, ResponseError{
+		Details: details,
+		Status:  derivedStatus,
+	})
+
+	return jre
+}
+
+// Render marshals the JSONResponseError to a valid JSON string and sets the
+// Output field to the rendered output. This method does not simply marshal the
+// instance, but also formats the output to a usable format for responses.
+func (jre *JSONResponseError) Render() string {
+	jsonBag := struct {
+		Errors []ResponseError `json:"errors"`
+		Status int             `json:"status,string"`
+	}{
+		jre.Errors(),
+		jre.Status(),
+	}
+	response, _ := json.Marshal(jsonBag)
+	jre.Output = string(response)
+
+	return jre.Output
+}
+
+// RespondJSONError will bootstrap and write out a valid json repsonse using the
+// provided JSONResponseError. It returns the results of fmt.Printf against the
+// provided http.ResponseWriter, which is expected to be the number of bytes
+// written and any write error encountered.
+func RespondJSONError(w http.ResponseWriter, jre *JSONResponseError) (int, error) {
+	w.Header().Set("content-type", "application/json")
+	return fmt.Fprint(w, jre.Render())
+}

--- a/app/handlers/jsonutil/json_test.go
+++ b/app/handlers/jsonutil/json_test.go
@@ -1,0 +1,75 @@
+package jsonutil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJsonResponseErrorInitialization(t *testing.T) {
+	jre := NewJSONResponseError(500)
+	assert.Equal(t, "*jsonutil.JSONResponseError", reflect.TypeOf(jre).String())
+	assert.Equal(t, 500, jre.Status())
+}
+
+func TestAddingErrors(t *testing.T) {
+	// Handling addition of error w/ default status code
+	jre := NewJSONResponseError(500).AddError("Example error")
+	error := jre.Errors()[0]
+	assert.Equal(t, 500, jre.Status())
+	assert.Equal(t, "Example error", error.Details)
+	assert.Equal(t, 500, error.Status)
+
+	jre = NewJSONResponseError(400).AddError("newman.gif", 401)
+	error = jre.Errors()[0]
+	assert.Equal(t, 400, jre.Status())
+	assert.Equal(t, "newman.gif", error.Details)
+	assert.Equal(t, 401, error.Status)
+
+	jre = NewJSONResponseError(400).AddError("newman.gif", 401).AddError("User not found", 404)
+	firstError := jre.Errors()[0]
+	secondError := jre.Errors()[1]
+	assert.Equal(t, 400, jre.Status())
+	assert.Equal(t, "newman.gif", firstError.Details)
+	assert.Equal(t, 401, firstError.Status)
+	assert.Equal(t, "User not found", secondError.Details)
+	assert.Equal(t, 404, secondError.Status)
+
+	jre = NewJSONResponseError(400).AddError("newman.gif").AddError("User not found", 404)
+	firstError = jre.Errors()[0]
+	secondError = jre.Errors()[1]
+	assert.Equal(t, 400, jre.Status())
+	assert.Equal(t, "newman.gif", firstError.Details)
+	assert.Equal(t, 400, firstError.Status)
+	assert.Equal(t, "User not found", secondError.Details)
+	assert.Equal(t, 404, secondError.Status)
+}
+
+func TestAddingErrorsShorthand(t *testing.T) {
+	// Handling addition of error w/ default status code using shorthand style
+	jre := NewJSONResponseError(500, "Example error")
+	error := jre.Errors()[0]
+	assert.Equal(t, 500, jre.Status())
+	assert.Equal(t, "Example error", error.Details)
+	assert.Equal(t, 500, error.Status)
+
+	jre = NewJSONResponseError(400, "newman.gif", "client-side error occurred")
+	firstError := jre.Errors()[0]
+	secondError := jre.Errors()[1]
+	assert.Equal(t, 400, jre.Status())
+	assert.Equal(t, "newman.gif", firstError.Details)
+	assert.Equal(t, 400, firstError.Status)
+	assert.Equal(t, "client-side error occurred", secondError.Details)
+	assert.Equal(t, 400, secondError.Status)
+}
+
+func TestRenderOutput(t *testing.T) {
+	json := NewJSONResponseError(500).AddError("Example error").Render()
+	expectedJSON := "{\"errors\":[{\"details\":\"Example error\",\"status\":\"500\"}],\"status\":\"500\"}"
+	assert.Equal(t, expectedJSON, json)
+
+	json = NewJSONResponseError(500).AddError("A different error", 503).Render()
+	expectedJSON = "{\"errors\":[{\"details\":\"A different error\",\"status\":\"503\"}],\"status\":\"500\"}"
+	assert.Equal(t, expectedJSON, json)
+}

--- a/database/model.go
+++ b/database/model.go
@@ -6,7 +6,7 @@ import (
 
 // Model base ORM struct
 type Model struct {
-	ID        uint `gorm:"primary_key"`
+	ID        uint `gorm:"primary_key" json:"ID,string"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/vendor/github.com/ricardolonga/jsongo/LICENSE
+++ b/vendor/github.com/ricardolonga/jsongo/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Ricardo Longa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/ricardolonga/jsongo/README.md
+++ b/vendor/github.com/ricardolonga/jsongo/README.md
@@ -1,0 +1,80 @@
+Jsongo
+===================
+
+**Fluent API** to make it easier **to create Json** objects.
+
+[![travis-ci](https://travis-ci.org/ricardolonga/jsongo.svg)](https://travis-ci.org/ricardolonga/jsongo) 
+[![codecov](https://codecov.io/gh/ricardolonga/jsongo/branch/master/graph/badge.svg)](https://codecov.io/gh/ricardolonga/jsongo)
+[![goreportcard](https://goreportcard.com/badge/github.com/ricardolonga/jsongo)](http://gocover.io/github.com/ricardolonga/jsongo)
+
+Install
+-------------
+```
+go get github.com/ricardolonga/jsongo
+```
+
+Usage
+-------------
+To create this:  
+```
+{  
+    "name":"Ricardo Longa",
+    "idade":28,
+    "owner":true,
+    "skills":[  
+        "Golang",
+        "Android"
+    ]
+}
+```  
+Do this:  
+```
+import (
+    j "github.com/ricardolonga/jsongo"
+)
+
+json := j.Object().Put("name", "Ricardo Longa").
+				   Put("idade", 28).
+				   Put("owner", true).
+				   Put("skills", j.Array().Put("Golang").
+									       Put("Android"))
+
+log.Println(json.Indent())
+log.Println(json.String())
+```
+##### Convert object/array to indented String:
+```
+json.Indent()
+```
+##### Convert object/array to String:
+```
+json.String()
+```
+##### To remove a field of the object:
+```
+json.Remove("skills")
+```
+##### To get a field of the object:
+```
+json.Get("skills") // Return is interface{}.
+```
+##### To range over a array:
+```
+results := Array().Put("Golang").Put("Android").Put("Java")
+
+for i, result := range results.Array() {
+}
+```
+##### To get Array size:
+```
+array := j.Array().Put("Android").
+                   Put("Golang").
+                   Put("Java")
+                   
+array.Size() // Result is 3.
+```
+
+Copyright
+-------------
+Copyright (c) 2015 Ricardo Longa.  
+Jsongo is licensed under the **Apache License Version 2.0**. See the LICENSE file for more information.

--- a/vendor/github.com/ricardolonga/jsongo/array.go
+++ b/vendor/github.com/ricardolonga/jsongo/array.go
@@ -1,0 +1,42 @@
+package jsongo
+
+import (
+	"reflect"
+	"errors"
+	"fmt"
+)
+
+type A []interface{}
+
+func Array() *A {
+	return &A{}
+}
+
+func (this *A) Put(value interface{}) *A {
+	*this = append(*this, value)
+	return this
+}
+
+func (this *A) Indent() string {
+	return indent(this)
+}
+
+func (this *A) String() string {
+	return _string(this)
+}
+
+func (this *A) Size() int {
+	return len(*this)
+}
+
+func (this *A) OfString() (values []string, err error) {
+	for _, value := range *this {
+		if reflect.TypeOf(value).String() != "string" {
+			return nil, errors.New(fmt.Sprintf("Value is %s, not a string.", reflect.TypeOf(value)))
+		}
+
+		values = append(values, value.(string))
+	}
+
+	return values, nil
+}

--- a/vendor/github.com/ricardolonga/jsongo/array_test.go
+++ b/vendor/github.com/ricardolonga/jsongo/array_test.go
@@ -1,0 +1,68 @@
+package jsongo
+
+import (
+	"testing"
+	"bytes"
+	"strings"
+)
+
+func Test_create_two_populated_objects_into_array(t *testing.T) {
+	expect := bytes2json([]byte(`{"funcionarios":[{"name":"Ricardo Longa","idade":28,"skills":["Golang","Android"]},{"name":"Hery Victor","idade":32,"skills":["Golang","Java"]}]}`))
+	result := Object().Put("funcionarios", Array().Put(Object().Put("name", "Ricardo Longa").Put("idade", 28).Put("skills", Array().Put("Golang").Put("Android"))).
+												   Put(Object().Put("name", "Hery Victor").Put("idade", 32).Put("skills", Array().Put("Golang").Put("Java"))))
+
+	check(t, struct2json(expect), struct2json(result))
+}
+
+func Test_array_size_must_be_3(t *testing.T) {
+	result := Array().Put("Golang").Put("Android").Put("Java")
+
+	check(t, 3, result.Size())
+}
+
+func Test_range_array(t *testing.T) {
+	results := Array().Put("Golang").Put("Android").Put("Java")
+
+	expect := make(map[int]string, 0)
+	expect[0] = "Golang"
+	expect[1] = "Android"
+	expect[2] = "Java"
+
+	arrayOfString, _ := results.OfString()
+
+	for i, result := range arrayOfString {
+		if !strings.EqualFold(result, expect[i]) {
+			t.Errorf("\n\nExpect: %s\nResult: %s", expect[i], result)
+		}
+	}
+}
+
+func Test_array_indent(t *testing.T) {
+	expect := []byte(`[
+   "Golang",
+   "Android",
+   "Java"
+]`)
+	result := Array().Put("Golang").Put("Android").Put("Java")
+
+	if !bytes.Equal(expect, bytes.NewBufferString(result.Indent()).Bytes()) {
+		t.Errorf("\n\nExpect: %s\nResult: %s", expect, result)
+	}
+}
+
+func Test_array_string(t *testing.T) {
+	expect := []byte(`["Golang","Android","Java"]`)
+	result := Array().Put("Golang").Put("Android").Put("Java")
+
+	if !bytes.Equal(expect, bytes.NewBufferString(result.String()).Bytes()) {
+		t.Errorf("\n\nExpect: %s\nResult: %s", expect, struct2json(result.String()))
+	}
+}
+
+func Test_error_expected_because_contains_a_int_value(t *testing.T) {
+	array := Array().Put("Golang").Put(123).Put("Java")
+
+	if _, err := array.OfString(); err == nil {
+		t.Errorf("Error expected because this array contains a not string value.")
+	}
+}

--- a/vendor/github.com/ricardolonga/jsongo/object.go
+++ b/vendor/github.com/ricardolonga/jsongo/object.go
@@ -1,0 +1,79 @@
+package jsongo
+
+import (
+	"errors"
+	"reflect"
+	"fmt"
+)
+
+type O map[string]interface{}
+
+func Object() O {
+	return O{}
+}
+
+func (this O) Put(key string, value interface{}) O {
+	this[key] = value
+	return this
+}
+
+func (this O) Get(key string) interface{} {
+	return this[key]
+}
+
+func (this O) GetObject(key string) (value O, err error) {
+	switch this[key].(type) {
+	case map[string]interface{}:
+		object := Object()
+
+		for k,v := range this[key].(map[string]interface{}) {
+			object.Put(k,v)
+		}
+
+		return object, nil
+	case O:
+		return this[key].(O), nil
+	}
+
+	return nil, errors.New(fmt.Sprintf("Casting error. Interface is %s, not jsongo.object", reflect.TypeOf(this[key])))
+}
+
+func (this O) GetArray(key string) (newArray *A, err error) {
+	newArray = Array()
+
+	switch this[key].(type) {
+	case []interface{}:
+		values := this[key].([]interface{})
+
+		for _, value := range values {
+			newArray.Put(value)
+		}
+
+		return newArray, nil
+	case []string:
+		values := this[key].([]string)
+
+		for _, value := range values {
+			newArray.Put(value)
+		}
+
+		return newArray, nil
+	case *A:
+		return this[key].(*A), nil
+	}
+
+	return nil, errors.New(fmt.Sprintf("Casting error. Interface is %s, not jsongo.A or []interface{}", reflect.TypeOf(this[key])))
+}
+
+func (this O) Remove(key string) O {
+	delete(this, key)
+	return this
+}
+
+func (this O) Indent() string {
+	return indent(this)
+}
+
+func (this O) String() string {
+	return _string(this)
+}

--- a/vendor/github.com/ricardolonga/jsongo/object_test.go
+++ b/vendor/github.com/ricardolonga/jsongo/object_test.go
@@ -1,0 +1,136 @@
+package jsongo
+
+import (
+	"testing"
+	"bytes"
+	"strings"
+)
+
+func Test_create_empty_object(t *testing.T) {
+	expect := bytes2json([]byte(`{}`))
+	result := Object()
+
+	check(t, struct2json(expect), struct2json(result))
+}
+
+func Test_create_populated_object(t *testing.T) {
+	expect := bytes2json([]byte(`{"name":"Ricardo Longa","idade":28,"owner":true,"skills":["Golang","Android"]}`))
+	result := Object().Put("name", "Ricardo Longa").Put("idade", 28).Put("owner", true).Put("skills", Array().Put("Golang").Put("Android"))
+
+	check(t, struct2json(expect), struct2json(result))
+}
+
+func Test_create_populated_objects_and_remove_attr(t *testing.T) {
+	expect := bytes2json([]byte(`{"name":"Ricardo Longa","idade":28,"skills":["Golang","Android"]}`))
+	result := Object().Put("name", "Ricardo Longa").Put("idade", 28).Put("skills", Array().Put("Golang").Put("Android"))
+
+	check(t, struct2json(expect), struct2json(result))
+
+	expectAfterRemove := bytes2json([]byte(`{"name":"Ricardo Longa","idade":28}`))
+
+	result.Remove("skills")
+
+	check(t, struct2json(expectAfterRemove), struct2json(result))
+}
+
+func Test_object_get_func(t *testing.T) {
+	expect := "Ricardo Longa"
+	result := Object().Put("name", "Ricardo Longa")
+
+	if !strings.EqualFold(expect, result.Get("name").(string)) {
+		t.Errorf("\n\nExpect: %s\nResult: %s", expect, result.Get("name"))
+	}
+}
+
+func Test_object_indent(t *testing.T) {
+	expect := []byte(`{
+   "skills": [
+      "Golang",
+      "Android",
+      "Java"
+   ]
+}`)
+	result := Object().Put("skills", Array().Put("Golang").Put("Android").Put("Java"))
+
+	if !bytes.Equal(expect, bytes.NewBufferString(result.Indent()).Bytes()) {
+		t.Errorf("\n\nExpect: %s\nResult: %s", expect, struct2json(result.Indent()))
+	}
+}
+
+func Test_object_string(t *testing.T) {
+	expect := []byte(`{"skills":["Golang","Android","Java"]}`)
+	result := Object().Put("skills", Array().Put("Golang").Put("Android").Put("Java"))
+
+	if !bytes.Equal(expect, bytes.NewBufferString(result.String()).Bytes()) {
+		t.Errorf("\n\nExpect: %s\nResult: %s", expect, struct2json(result.String()))
+	}
+}
+
+func Test_get_object_with_casting_error(t *testing.T) {
+	obj := Object().Put("skills", Array().Put("Golang").Put("Android").Put("Java"))
+
+	if _, err := obj.GetObject("skills"); err == nil {
+		t.Errorf("Casting error not found.")
+	}
+}
+
+func Test_get_object_without_casting_error(t *testing.T) {
+	obj := Object().Put("owner", Object().Put("nome", "Ricardo Longa"))
+
+	_, err := obj.GetObject("owner")
+	if err != nil {
+		t.Errorf("1Casting error not expected.")
+	}
+
+	obj = Object().Put("owner", map[string]interface{}{
+		"nome":"Ricardo Longa",
+	})
+
+	obj, err = obj.GetObject("owner")
+	if err != nil {
+		t.Errorf("2Casting error not expected.")
+	}
+}
+
+func Test_get_array_without_casting_error(t *testing.T) {
+	obj := Object().Put("skills", Array().Put("Golang").Put("Android").Put("Java"))
+
+	values, err := obj.GetArray("skills")
+	if err != nil {
+		t.Errorf("Error not expected: %s.", err)
+	}
+
+	if len(*values) != 3 {
+		t.Error("Expected 3 values.")
+	}
+
+	obj = Object().Put("skills", []interface{}{"Golang", "Android", "Java"})
+
+	values, err = obj.GetArray("skills")
+	if err != nil {
+		t.Errorf("Error not expected: %s.", err)
+	}
+
+	if len(*values) != 3 {
+		t.Error("Expected 3 values.")
+	}
+
+	obj = Object().Put("skills", []string{"Golang", "Android", "Java"})
+
+	values, err = obj.GetArray("skills")
+	if err != nil {
+		t.Errorf("Error not expected: %s.", err)
+	}
+
+	if len(*values) != 3 {
+		t.Error("Expected 3 values.")
+	}
+}
+
+func Test_get_array_with_casting_error(t *testing.T) {
+	obj := Object().Put("owner", Object().Put("nome", "Ricardo Longa"))
+
+	if _, err := obj.GetArray("owner"); err == nil {
+		t.Errorf("Casting error not found.")
+	}
+}

--- a/vendor/github.com/ricardolonga/jsongo/util.go
+++ b/vendor/github.com/ricardolonga/jsongo/util.go
@@ -1,0 +1,13 @@
+package jsongo
+
+import "encoding/json"
+
+func indent(v interface{}) string {
+	indent, _ := json.MarshalIndent(v, "", "   ")
+	return string(indent)
+}
+
+func _string(v interface{}) string {
+	indent, _ := json.Marshal(v)
+	return string(indent)
+}

--- a/vendor/github.com/ricardolonga/jsongo/util_test.go
+++ b/vendor/github.com/ricardolonga/jsongo/util_test.go
@@ -1,0 +1,38 @@
+package jsongo
+
+import (
+	"log"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func bytes2json(data []byte) map[string]interface{} {
+	var jsonData interface{}
+
+	err := json.Unmarshal(data, &jsonData)
+
+	if err != nil {
+		log.Printf("Erro: %s", err)
+		return nil
+	}
+
+	return jsonData.(map[string]interface{})
+}
+
+func struct2json(data interface{}) string {
+	byteArray, err := json.Marshal(data)
+
+	if err != nil {
+		log.Printf("Erro: %s", err)
+		return ""
+	}
+
+	return string(byteArray)
+}
+
+func check(t *testing.T, expect, result interface{}) {
+	if !reflect.DeepEqual(expect, result) {
+		t.Errorf("\n\nExpect: %s\nResult: %s", expect, result)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -343,6 +343,12 @@
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
+			"checksumSHA1": "RMSzeJov3QKqWd8TIvuTstIHAs4=",
+			"path": "github.com/ricardolonga/jsongo",
+			"revision": "459112a8028dfbecd765e6ee2bd775f4652f270c",
+			"revisionTime": "2016-12-15T11:09:33Z"
+		},
+		{
 			"checksumSHA1": "x6WnPggr3ijX7c/7g5q8hIePN+s=",
 			"path": "github.com/smartystreets/assertions",
 			"revision": "e60cfa771e3f4d18723a4119f1833898c9c62066",


### PR DESCRIPTION
Addition of a jsonutil package to help manage error responses for api responses. Handlers in the api section have been refactored to use this new package. A field tag was added to the ID field of the base database.Model struct to force json marshalling to return a string.