### PR TITLE
UI Pipeline Fix

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -54,8 +54,8 @@ build-ui:
         name: ui build
         code: |
           cd ui
-          node install
-          node run build
+          npm install
+          npm run build
     - script:
         name: clean up
         code: |


### PR DESCRIPTION
The `build-ui` pipeline had `node install` and `node run build` instead of `npm install` and `npm run build`. This PR fixes those commands.