### PR TITLE
Access tokens can now be used for authentication

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -42,6 +42,7 @@ func New() *Application {
 	brizo.migrator = database.Migrate
 	brizo.shouldMigrate = []interface{}{
 		&auth.User{},
+		&resources.AccessToken{},
 		&resources.Application{},
 		&resources.Environment{},
 	}

--- a/app/handlers/api/access_tokens.go
+++ b/app/handlers/api/access_tokens.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/generationtux/brizo/database"
+	"github.com/generationtux/brizo/resources"
+)
+
+// AccessTokenCreate creates a new AccessToken
+func AccessTokenCreate(w http.ResponseWriter, r *http.Request) {
+	db, err := database.Connect()
+	defer db.Close()
+	if err != nil {
+		log.Printf("Database error: '%s'\n", err)
+		http.Error(w, "there was an error when attempting to connect to the database", http.StatusInternalServerError)
+		return
+	}
+
+	token, err := resources.CreateRandomAccessToken(db)
+	// @todo handle failed save w/out error?
+	if err != nil {
+		log.Printf("Error when creating access token: '%s'\n", err)
+		http.Error(w, "there was an error when creating access token", http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(token)
+	w.WriteHeader(http.StatusCreated)
+}

--- a/app/routes/apiRoutes.go
+++ b/app/routes/apiRoutes.go
@@ -13,6 +13,9 @@ func authAPIRoutes() *bone.Mux {
 	router.PostFunc("/users", api.AuthCreateUser)
 	router.GetFunc("/users/invites", api.AuthGetInvitees)
 
+	// access tokens
+	router.PostFunc("/access-tokens", api.AccessTokenCreate)
+
 	// applications
 	router.GetFunc("/applications", api.ApplicationIndex)
 	router.GetFunc("/applications/:uuid", api.ApplicationShow)

--- a/auth/guard.go
+++ b/auth/guard.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/generationtux/brizo/database"
+	"github.com/generationtux/brizo/resources"
 )
 
 // APIMiddleware authenticates API requests
@@ -26,14 +28,31 @@ func APIMiddleware(rw http.ResponseWriter, request *http.Request, next http.Hand
 		return
 	}
 
-	jwtToken := extractJWTFromHeader(authHeader)
-	if !ValidateJWTToken(jwtToken) {
-		rw.WriteHeader(401)
-		rw.Write([]byte("not authorized"))
+	jwtToken := extractBearerTokenFromHeader(authHeader)
+	if ValidateJWTToken(jwtToken) || ValidatePersonalAccessToken(jwtToken) {
+		next(rw, request)
 		return
 	}
 
-	next(rw, request)
+	rw.WriteHeader(401)
+	rw.Write([]byte("not authorized"))
+}
+
+func ValidatePersonalAccessToken(token string) bool {
+	fmt.Printf("token: %v\n", token)
+	// @todo this db connection stuff's is a real mess. This should be kicked into
+	// callback or something to allow for any db connections to be caught?
+	db, err := database.Connect()
+	defer db.Close()
+	if err != nil {
+		log.Printf("Database error: '%s'\n", err)
+		// http.Error(w, "there was an error when attempting to connect to the database", http.StatusInternalServerError)
+		return false
+	}
+	if resources.HasAccessToken(db, token) {
+		return true
+	}
+	return false
 }
 
 // validateAuthHeader will ensure the header is formatted correctly
@@ -68,8 +87,8 @@ func jwtSecret() string {
 	return os.Getenv("JWT_SECRET")
 }
 
-// extractJWTFromHeader will parse the header string and return just the token
+// extractBearerTokenFromHeader will parse the header string and return just the token
 // header should be formatted as Bearer [TOKEN]
-func extractJWTFromHeader(header string) string {
+func extractBearerTokenFromHeader(header string) string {
 	return header[7:]
 }

--- a/auth/guard.go
+++ b/auth/guard.go
@@ -38,8 +38,9 @@ func APIMiddleware(rw http.ResponseWriter, request *http.Request, next http.Hand
 	rw.Write([]byte("not authorized"))
 }
 
+// ValidatePersonalAccessToken check that a valid access token exists in the
+// database.
 func ValidatePersonalAccessToken(token string) bool {
-	fmt.Printf("token: %v\n", token)
 	// @todo this db connection stuff's is a real mess. This should be kicked into
 	// callback or something to allow for any db connections to be caught?
 	db, err := database.Connect()

--- a/auth/guard_test.go
+++ b/auth/guard_test.go
@@ -34,9 +34,9 @@ func TestAPIMiddlewareInvalidHeader(t *testing.T) {
 	rw.AssertExpectations(t)
 }
 
-func TestExtractJWTFromHeader(t *testing.T) {
+func TestExtractBearerTokenFromHeader(t *testing.T) {
 	header := "Bearer tokenabc123"
-	token := extractJWTFromHeader(header)
+	token := extractBearerTokenFromHeader(header)
 	assert.Equal(t, "tokenabc123", token)
 }
 

--- a/auth/register.go
+++ b/auth/register.go
@@ -9,7 +9,7 @@ import (
 
 // GetOAuthStateString provides a randomized string to prevent csrf
 func GetOAuthStateString() (oauthStateString string) {
-	return generateRandomString(64)
+	return GenerateRandomString(64)
 }
 
 // CreateNewGithubUser takes oauth response values and creates a new Brizo user

--- a/auth/util.go
+++ b/auth/util.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func generateRandomString(length int) string {
+func GenerateRandomString(length int) string {
 	const characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/auth/util.go
+++ b/auth/util.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// GenerateRandomString will provide a [0-9a-Z] string of a specified length.
 func GenerateRandomString(length int) string {
 	const characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 

--- a/auth/util_test.go
+++ b/auth/util_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRandomStringIsGenerated(t *testing.T) {
-	generatedString := generateRandomString(32)
+	generatedString := GenerateRandomString(32)
 	matches, _ := regexp.Match("[a-zA-Z0-9]", []byte(generatedString))
 
 	assert.Len(t, generatedString, 32)

--- a/resources/access_token.go
+++ b/resources/access_token.go
@@ -1,0 +1,87 @@
+package resources
+
+import (
+	"errors"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/generationtux/brizo/database"
+	"github.com/jinzhu/gorm"
+)
+
+// PersonalAccessTokenLength is used to create and validate personal access tokens
+const PersonalAccessTokenLength = 128
+
+func generateRandomString(length int) string {
+	const characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bytes := make([]byte, length)
+	for i := range bytes {
+		bytes[i] = characters[r.Intn(len(characters))]
+	}
+
+	return string(bytes)
+}
+
+// AccessToken as defined by Brizo.
+type AccessToken struct {
+	database.Model
+	Token string `gorm:"not null;unique_index" sql:"type:varchar(128)" json:"token"`
+}
+
+// BeforeCreate is a hook that runs before inserting a new record into the database
+func (a *AccessToken) BeforeCreate() (err error) {
+	if a.Token == "" {
+		a.Token = generateRandomString(PersonalAccessTokenLength)
+	}
+
+	return
+}
+
+// CreateAccessToken will add a new AccessToken to Brizo.
+func CreateAccessToken(db *gorm.DB, token *AccessToken) (bool, error) {
+	result := db.Create(&token)
+
+	return result.RowsAffected == 1, result.Error
+}
+
+// CreateRandomAccessToken will create a new AccessToken without requiring a
+// pepared access token instance.
+func CreateRandomAccessToken(db *gorm.DB) (*AccessToken, error) {
+	token := &AccessToken{}
+	token.Token = generateRandomString(PersonalAccessTokenLength)
+	successful, err := CreateAccessToken(db, token)
+	if err != nil || !successful {
+		log.Printf("Error when creating access token: '%s'\n", err)
+		return &AccessToken{}, errors.New("there was an error when creating access token")
+	}
+
+	return token, nil
+}
+
+// GetAccessToken will get an existing access token by it's token string
+func GetAccessToken(db *gorm.DB, token string) (*AccessToken, error) {
+	accessToken := new(AccessToken)
+	if err := db.Where("token = ?", token).First(&accessToken).Error; err != nil {
+		return accessToken, err
+	}
+
+	if accessToken.ID == 0 {
+		return new(AccessToken), errors.New("not-found")
+	}
+
+	return accessToken, nil
+}
+
+// HasAccessToken will return the existance of an access token in the database.
+// Errors that occur on the passed db instance will not be returned, so the
+// caller should check for any errors if desired.
+func HasAccessToken(db *gorm.DB, token string) bool {
+	if db.Where("token = ?", token).First(&AccessToken{}).RecordNotFound() {
+		return false
+	}
+
+	return true
+}

--- a/resources/access_token_test.go
+++ b/resources/access_token_test.go
@@ -10,56 +10,62 @@ import (
 )
 
 func TestCanCreateAnAccessToken(t *testing.T) {
-	token := generateRandomString(PersonalAccessTokenLength)
-	accessToken := AccessToken{
-		Token: token,
-	}
-	db, _ := gorm.Open("testdb", "")
 	var query string
 	var args []driver.Value
-
 	testdb.SetExecWithArgsFunc(func(q string, a []driver.Value) (driver.Result, error) {
 		query = q
 		args = a
 		return driver.ResultNoRows, nil
 	})
 
+	token := generateRandomString(PersonalAccessTokenLength)
+	accessToken := AccessToken{
+		Token: token,
+	}
+	db, _ := gorm.Open("testdb", "")
+	defer db.Close()
+
 	CreateAccessToken(db, &accessToken)
+
 	expectQuery := "INSERT INTO \"access_tokens\" (\"created_at\",\"updated_at\",\"token\") VALUES (?,?,?)"
 	assert.Equal(t, expectQuery, query)
 	assert.Equal(t, token, args[2])
 }
 
-// func TestCanCheckExistanceOfAnAccessToken(t *testing.T) {
-// 	token := generateRandomString(PersonalAccessTokenLength)
-// 	db, _ := gorm.Open("testdb", "")
-// 	var query string
-// 	var args []driver.Value
-//
-// 	testdb.SetExecWithArgsFunc(func(q string, a []driver.Value) (driver.Result, error) {
-// 		query = q
-// 		args = a
-// 		return driver.ResultNoRows, nil
-// 	})
-//
-// 	HasAccessToken(db, token)
-// 	expectQuery := "SELECT * FROM \"access_tokens\" WHERE token = " + token
-// 	assert.Equal(t, expectQuery, query)
-// }
+func TestCanCheckExistanceOfAnAccessToken(t *testing.T) {
+	testdb.SetQueryWithArgsFunc(func(q string, args []driver.Value) (driver.Rows, error) {
+		columns := []string{"id", "created_at", "updated_at", "token"}
+		var rows string
+		if args[0] == "existingToken" {
+			rows = "1,2017-02-01 09:00:00,2017-02-01 09:00:00,existingToken"
+		}
+		return testdb.RowsFromCSVString(columns, rows), nil
+	})
 
-// func TestCanCreateAnRandomAccessToken(t *testing.T) {
-// 	db, _ := gorm.Open("testdb", "")
-// 	var query string
-// 	var args []driver.Value
-//
-// 	testdb.SetExecWithArgsFunc(func(q string, a []driver.Value) (driver.Result, error) {
-// 		query = q
-// 		args = a
-// 		return driver.ResultNoRows, nil
-// 	})
-//
-// 	token, _ := CreateRandomAccessToken(db)
-// 	expectQuery := "INSERT INTO \"access_tokens\" (\"created_at\",\"updated_at\",\"token\") VALUES (?,?,?)"
-// 	assert.Equal(t, expectQuery, query)
-// 	assert.Len(t, token.Token, auth.PersonalAccessTokenLength)
-// }
+	db, _ := gorm.Open("testdb", "")
+	defer db.Close()
+	found := HasAccessToken(db, "existingToken")
+	missing := HasAccessToken(db, "missingToken")
+
+	assert.True(t, found)
+	assert.False(t, missing)
+}
+
+func TestCanCreateAnRandomAccessToken(t *testing.T) {
+	var query string
+	var args []driver.Value
+	result := testdb.NewResult(1, nil, 1, nil)
+	testdb.SetExecWithArgsFunc(func(q string, a []driver.Value) (driver.Result, error) {
+		query = q
+		args = a
+		return result, nil
+	})
+
+	db, _ := gorm.Open("testdb", "")
+	defer db.Close()
+	token, _ := CreateRandomAccessToken(db)
+
+	expectQuery := "INSERT INTO \"access_tokens\" (\"created_at\",\"updated_at\",\"token\") VALUES (?,?,?)"
+	assert.Equal(t, expectQuery, query)
+	assert.Len(t, token.Token, PersonalAccessTokenLength)
+}

--- a/resources/access_token_test.go
+++ b/resources/access_token_test.go
@@ -1,0 +1,65 @@
+package resources
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	testdb "github.com/erikstmartin/go-testdb"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanCreateAnAccessToken(t *testing.T) {
+	token := generateRandomString(PersonalAccessTokenLength)
+	accessToken := AccessToken{
+		Token: token,
+	}
+	db, _ := gorm.Open("testdb", "")
+	var query string
+	var args []driver.Value
+
+	testdb.SetExecWithArgsFunc(func(q string, a []driver.Value) (driver.Result, error) {
+		query = q
+		args = a
+		return driver.ResultNoRows, nil
+	})
+
+	CreateAccessToken(db, &accessToken)
+	expectQuery := "INSERT INTO \"access_tokens\" (\"created_at\",\"updated_at\",\"token\") VALUES (?,?,?)"
+	assert.Equal(t, expectQuery, query)
+	assert.Equal(t, token, args[2])
+}
+
+// func TestCanCheckExistanceOfAnAccessToken(t *testing.T) {
+// 	token := generateRandomString(PersonalAccessTokenLength)
+// 	db, _ := gorm.Open("testdb", "")
+// 	var query string
+// 	var args []driver.Value
+//
+// 	testdb.SetExecWithArgsFunc(func(q string, a []driver.Value) (driver.Result, error) {
+// 		query = q
+// 		args = a
+// 		return driver.ResultNoRows, nil
+// 	})
+//
+// 	HasAccessToken(db, token)
+// 	expectQuery := "SELECT * FROM \"access_tokens\" WHERE token = " + token
+// 	assert.Equal(t, expectQuery, query)
+// }
+
+// func TestCanCreateAnRandomAccessToken(t *testing.T) {
+// 	db, _ := gorm.Open("testdb", "")
+// 	var query string
+// 	var args []driver.Value
+//
+// 	testdb.SetExecWithArgsFunc(func(q string, a []driver.Value) (driver.Result, error) {
+// 		query = q
+// 		args = a
+// 		return driver.ResultNoRows, nil
+// 	})
+//
+// 	token, _ := CreateRandomAccessToken(db)
+// 	expectQuery := "INSERT INTO \"access_tokens\" (\"created_at\",\"updated_at\",\"token\") VALUES (?,?,?)"
+// 	assert.Equal(t, expectQuery, query)
+// 	assert.Len(t, token.Token, auth.PersonalAccessTokenLength)
+// }


### PR DESCRIPTION
A new resource and migration has been setup for access tokens. They are currently just 128 character strings, but we can move to a more standardized form of generation if that exists.

This has some commented out tests that have me scratching my head, so I'm assuming that I'm missing something there. I'm pushing this up just as a reference and to start getting early feedback.