### PR TITLE
bugfix: missing Github attrs failed user creation

### DIFF
--- a/app/handlers/web/auth.go
+++ b/app/handlers/web/auth.go
@@ -12,21 +12,6 @@ import (
 	"golang.org/x/oauth2/github"
 )
 
-const htmlAddUser = `<!doctype html><html><body>
-<form action="/api/v1/users" method="post">
-  <label>Add user:</label>
-  <input type="text" name="username">
-</form>
-</body></html>
-`
-
-// AuthAddNewUser @todo move to JS UI
-func AuthAddNewUser(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(htmlAddUser))
-}
-
 var (
 	oauthConf = &oauth2.Config{
 		ClientID:     "",
@@ -97,7 +82,7 @@ func AuthGithubCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	var jwtToken string
 	var jwtError error
 	if auth.IsFirstUser(db) {
-		user, err := auth.CreateNewGithubUser(db, user, token.AccessToken)
+		brizoUser, err := auth.CreateNewGithubUser(db, user, token.AccessToken)
 
 		if err != nil {
 			log.Println(err)
@@ -105,25 +90,15 @@ func AuthGithubCallbackHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		jwtToken, jwtError = auth.CreateJWTToken(user)
+		jwtToken, jwtError = auth.CreateJWTToken(brizoUser)
 	} else if auth.GithubUserAllowed(db, *user.Login) {
-		// @todo check that non-required attributes exist
-		brizoUser := auth.User{
-			Username:       *user.Login,
-			Name:           *user.Name,
-			Email:          *user.Email,
-			GithubUsername: *user.Login,
-			GithubToken:    token.AccessToken,
-		}
-
+		brizoUser := auth.BuildUserFromGithubUser(user, token.AccessToken)
 		success, err := auth.UpdateUser(db, &brizoUser)
 
 		if success == false || err != nil {
 			authErrorRedirect(w, r)
 			return
 		}
-
-		jwtToken, jwtError = auth.CreateJWTToken(brizoUser)
 	} else {
 		// user is not allowed
 		authDenyRedirect(w, r)

--- a/app/routes/rootRoutes.go
+++ b/app/routes/rootRoutes.go
@@ -28,9 +28,6 @@ func mainRoutes() *bone.Mux {
 	router.GetFunc("/o/auth/login/github", web.AuthGithubHandler)
 	router.GetFunc("/o/auth/callback/github", web.AuthGithubCallbackHandler)
 
-	// @todo move to JS UI
-	router.GetFunc("/users", web.AuthAddNewUser)
-
 	return router
 }
 

--- a/auth/register.go
+++ b/auth/register.go
@@ -14,16 +14,10 @@ func GetOAuthStateString() (oauthStateString string) {
 
 // BuildUserFromGithubUser handles the checks needed to build a brizo user from
 // possible github user attributes.
-func BuildUserFromGithubUser(githubUser *githuboauth.User, token string) User {
-	var (
-		email string
-		name  string
-	)
+func BuildUserFromGithubUser(githubUser *githuboauth.User, email string, token string) User {
+	var name string
 	if githubUser.Name != nil {
 		name = *githubUser.Name
-	}
-	if githubUser.Email != nil {
-		email = *githubUser.Email
 	}
 	return User{
 		Username:       *githubUser.Login,
@@ -35,8 +29,8 @@ func BuildUserFromGithubUser(githubUser *githuboauth.User, token string) User {
 }
 
 // CreateNewGithubUser takes oauth response values and creates a new Brizo user
-func CreateNewGithubUser(db *gorm.DB, githubUser *githuboauth.User, token string) (User, error) {
-	user := BuildUserFromGithubUser(githubUser, token)
+func CreateNewGithubUser(db *gorm.DB, githubUser *githuboauth.User, email string, token string) (User, error) {
+	user := BuildUserFromGithubUser(githubUser, email, token)
 	err := db.Create(&user).Error
 
 	return user, err

--- a/auth/register_test.go
+++ b/auth/register_test.go
@@ -42,7 +42,7 @@ func TestCreateNewGithubUser(t *testing.T) {
 		return driver.ResultNoRows, nil
 	})
 
-	CreateNewGithubUser(db, user, token)
+	CreateNewGithubUser(db, user, email, token)
 	expectQuery := "INSERT INTO \"users\" (\"created_at\",\"updated_at\",\"username\",\"name\",\"email\",\"github_username\",\"github_token\") VALUES (?,?,?,?,?,?,?)"
 	assert.Equal(t, expectQuery, query)
 	// args are prefixed with created_at and update_at


### PR DESCRIPTION
Previously, user creation would fail if an invitee did not have a public email and name for their Github profile. User creation now takes these missing attributes into account and handles creation gracefully.