### PR TITLE
create deployment definition for versions

### DIFF
--- a/resources/environment.go
+++ b/resources/environment.go
@@ -16,6 +16,7 @@ type Environment struct {
 	Name          string `gorm:"not null;unique_index" json:"name"`
 	Slug          string `gorm:"not null;unique_index" json:"slug"`
 	ApplicationID uint64 `json:"application_id,string"`
+	Application   Application
 }
 
 // BeforeCreate is a hook that runs before inserting a new record into the

--- a/resources/version_test.go
+++ b/resources/version_test.go
@@ -32,3 +32,32 @@ func TestCanCreateAVersion(t *testing.T) {
 	assert.Equal(t, id, args[2])
 	assert.Equal(t, "foobar", args[3])
 }
+
+func TestVersionDeploymentDefinition(t *testing.T) {
+	app := Application{Slug: "my-app", UUID: "app-uuid123"}
+	environment := Environment{Slug: "dev", UUID: "env-uuid123"}
+	environment.Application = app
+	version := &Version{
+		Environment: environment,
+		Name:        "version 1",
+		Slug:        "version-1",
+		Image:       "foo:latest",
+		UUID:        "version-uuid123",
+		Replicas:    3,
+	}
+
+	deployment := versionDeploymentDefinition(version)
+	assert.Equal(t, "my-app-dev-version-1", deployment.Name)
+	assert.Equal(t, "brizo", deployment.Namespace)
+	assert.Equal(t, int32(version.Replicas), *deployment.Spec.Replicas)
+	assert.Equal(t, "foo:latest", deployment.Spec.Template.Spec.Containers[0].Image)
+
+	expectDeploymentLabels := map[string]string{"brizoManaged": "true", "appUUID": "app-uuid123", "envUUID": "env-uuid123"}
+	assert.Equal(t, expectDeploymentLabels, deployment.Labels)
+
+	expectSelector := map[string]string{"envUUID": "env-uuid123", "versionUUID": "version-uuid123"}
+	assert.Equal(t, expectSelector, deployment.Spec.Selector.MatchLabels)
+
+	expectTemplateLabels := map[string]string{"brizoManaged": "true", "appUUID": "app-uuid123", "envUUID": "env-uuid123", "versionUUID": "version-uuid123"}
+	assert.Equal(t, expectTemplateLabels, deployment.Spec.Template.Labels)
+}


### PR DESCRIPTION
Method that accepts a version and build the appropriate deployment definition for Kube. Once the API refactors are complete from @jlaswell I'll hook this up to he CreateVersion method to utilize kube client and create the deployment in k8s before persisting to the database.