### PR TITLE
Support multiple containers for versions

### DIFF
--- a/app/handlers/api/versions.go
+++ b/app/handlers/api/versions.go
@@ -87,14 +87,10 @@ func VersionShow(w http.ResponseWriter, r *http.Request) {
 // VersionCreate creates a new Version
 func VersionCreate(w http.ResponseWriter, r *http.Request) {
 	var createForm struct {
-		Name         string                           `json:"name"`
-		Image        string                           `json:"image"`
-		Replicas     int                              `json:"replicas"`
-		Args         []string                         `json:"args"`
-		PullPolicy   string                           `json:"pullPolicy"`
-		Ports        []resources.ContainerPort        `json:"ports"`
-		VolumeMounts []resources.ContainerVolumeMount `json:"volumeMounts"`
-		Volumes      []resources.Volume               `json:"volumes"`
+		Name       string                `json:"name"`
+		Replicas   int                   `json:"replicas"`
+		Containers []resources.Container `json:"containers"`
+		Volumes    []resources.Volume    `json:"volumes"`
 	}
 	err := jsonRequest(r, &createForm)
 	if err != nil {
@@ -126,15 +122,11 @@ func VersionCreate(w http.ResponseWriter, r *http.Request) {
 	version := resources.Version{
 		Name:          createForm.Name,
 		Slug:          slugify.Slugify(createForm.Name),
-		Image:         createForm.Image,
+		Containers:    createForm.Containers,
 		Replicas:      createForm.Replicas,
 		Volumes:       createForm.Volumes,
 		EnvironmentID: environment.ID,
 		Environment:   *environment,
-		PullPolicy:    createForm.PullPolicy,
-		Args:          createForm.Args,
-		Ports:         createForm.Ports,
-		VolumeMounts:  createForm.VolumeMounts,
 	}
 
 	_, err = resources.CreateVersion(db, client, &version)

--- a/resources/version.go
+++ b/resources/version.go
@@ -23,12 +23,12 @@ type Volume struct {
 
 // Container individual container for a version
 type Container struct {
-	Name         string                 `gorm:"not null" json:"name"`
-	Image        string                 `gorm:"not null" json:"image"`
-	PullPolicy   string                 `gorm:"-" json:"pullPolicy"`
-	Args         []string               `gorm:"-" json:"args"`
-	VolumeMounts []ContainerVolumeMount `gorm:"-" json:"volumeMounts"`
-	Ports        []ContainerPort        `gorm:"-" json:"port"`
+	Name         string                 `json:"name"`
+	Image        string                 `json:"image"`
+	PullPolicy   string                 `json:"pullPolicy"`
+	Args         []string               `json:"args"`
+	VolumeMounts []ContainerVolumeMount `json:"volumeMounts"`
+	Ports        []ContainerPort        `json:"port"`
 }
 
 // ContainerPort exposed container port
@@ -151,7 +151,7 @@ func createContainerSpec(container Container) v1.Container {
 	}
 
 	return v1.Container{
-		Name:            "app",
+		Name:            container.Name,
 		Image:           container.Image,
 		ImagePullPolicy: policy,
 		Args:            container.Args,
@@ -174,9 +174,9 @@ func versionDeploymentDefinition(version *Version) *v1beta1.Deployment {
 		k8sVolumes = append(k8sVolumes, convertVolume(version.Volumes[index]))
 	}
 
-	k8sContainers := make([]v1.Container, len(version.Containers))
-	for i, container := range version.Containers {
-		k8sContainers[i] = createContainerSpec(container)
+	var k8sContainers []v1.Container
+	for index := 0; index < len(version.Containers); index++ {
+		k8sContainers = append(k8sContainers, createContainerSpec(version.Containers[index]))
 	}
 
 	deployment := &v1beta1.Deployment{

--- a/resources/version_test.go
+++ b/resources/version_test.go
@@ -50,7 +50,7 @@ func TestCanCreateAVersion(t *testing.T) {
 	})
 
 	CreateVersion(db, mockClient, &version)
-	expectQuery := "INSERT INTO \"versions\" (\"created_at\",\"updated_at\",\"uuid\",\"name\",\"slug\",\"image\",\"environment_id\",\"spec\") VALUES (?,?,?,?,?,?,?,?)"
+	expectQuery := "INSERT INTO \"versions\" (\"created_at\",\"updated_at\",\"uuid\",\"name\",\"slug\",\"environment_id\",\"spec\") VALUES (?,?,?,?,?,?,?)"
 	assert.Equal(t, expectQuery, query)
 	assert.Equal(t, id, args[2])
 	assert.Equal(t, "foobar", args[3])
@@ -58,7 +58,7 @@ func TestCanCreateAVersion(t *testing.T) {
 	deployment := versionDeploymentDefinition(&version)
 	expectSpec, err := json.Marshal(deployment)
 	assert.Nil(t, err)
-	assert.Equal(t, string(expectSpec), args[7])
+	assert.Equal(t, string(expectSpec), args[6])
 }
 
 func TestVersionDeploymentDefinition(t *testing.T) {
@@ -69,15 +69,21 @@ func TestVersionDeploymentDefinition(t *testing.T) {
 		Environment: environment,
 		Name:        "version 1",
 		Slug:        "version-1",
-		Image:       "foo:latest",
 		UUID:        "version-uuid123",
 		Replicas:    3,
+		Containers: []Container{
+			Container{
+				Name:  "app",
+				Image: "foo:latest",
+			},
+		},
 	}
 
 	deployment := versionDeploymentDefinition(version)
 	assert.Equal(t, "my-app-dev", deployment.Name)
 	assert.Equal(t, "brizo", deployment.Namespace)
 	assert.Equal(t, int32(version.Replicas), *deployment.Spec.Replicas)
+	assert.Equal(t, "app", deployment.Spec.Template.Spec.Containers[0].Name)
 	assert.Equal(t, "foo:latest", deployment.Spec.Template.Spec.Containers[0].Image)
 
 	expectDeploymentLabels := map[string]string{"brizoManaged": "true", "appUUID": "app-uuid123", "envUUID": "env-uuid123"}

--- a/ui/src/app/modules/versions/containers/container-form.component.ts
+++ b/ui/src/app/modules/versions/containers/container-form.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input } from '@angular/core';
+import { Volume } from '../version.model';
+import { Container, ContainerPort, VolumeMount } from './container.model';
+
+@Component({
+  selector: 'container-form',
+  templateUrl: './container-form.html',
+})
+
+export class ContainerFormComponent {
+  @Input() container: Container = new Container();
+  @Input() containerIndex: number;
+  @Input() availableVolumes: Volume[];
+
+  private selectedVolumeMount: string;
+
+  private addPort() {
+    this.container.ports.push(new ContainerPort());
+  }
+
+  private removePort(i: number) {
+    this.container.ports.splice(i, 1);
+  }
+
+  private addArg() {
+    this.container.args.push("");
+  }
+
+  private removeArg(i: number) {
+    this.container.args.splice(i, 1);
+  }
+
+  private addVolumeMount() {
+    let mount = new VolumeMount({
+      name: this.selectedVolumeMount,
+    });
+    this.container.volumeMounts.push(mount);
+  }
+
+  private removeVolumeMount(i: number) {
+    this.container.volumeMounts.splice(i, 1);
+  }
+}

--- a/ui/src/app/modules/versions/containers/container-form.html
+++ b/ui/src/app/modules/versions/containers/container-form.html
@@ -1,0 +1,87 @@
+<hr>
+
+<div class="form-group">
+  <label for="image">Image</label>
+  <input type="text" name="container-image-{{ containerIndex }}" [(ngModel)]="container.image" class="form-control" placeholder="image:latest">
+</div>
+
+<div class="form-group">
+  <label for="image">Pull policy</label>
+  <select class="form-control" name="container-pullPolicy-{{ containerIndex }}" [(ngModel)]="container.pullPolicy">
+    <option value="Always">Always</option>
+    <option value="IfNotPresent">If not present</option>
+    <option value="Never">Never</option>
+  </select>
+</div>
+
+<div class="form-group">
+  <label for="args">
+    Args
+    <span class="text-info" role="button" (click)="addArg()"><i class="fa fa-plus"></i></span>
+  </label>
+  <div *ngFor="let arg of container?.args; let i=index" class="form-group">
+    <div class="input-group">
+      <input type="text" name="container-argument-{{ containerIndex}}-{{ i }}" class="form-control" [(ngModel)]="container.args[i]">
+      <span class="input-group-addon">
+        <span class="text-danger" role="button" (click)="removeArg(i)">&times;</span>
+      </span>
+    </div>
+  </div>
+</div>
+
+<div class="form-group">
+  <label for="ports">
+    Ports
+    <span class="text-info" role="button" (click)="addPort()"><i class="fa fa-plus"></i></span>
+  </label>
+  <div *ngFor="let port of container.ports; let i=index">
+    <div class="row form-group">
+      <div class="col-sm-2">
+        <select name="port-protocol-{{ containerIndex }}-{{ i }}" [(ngModel)]="port.protocol" class="form-control">
+          <option value="TCP">TCP</option>
+          <option value="UDP">UDP</option>
+        </select>
+      </div>
+
+      <div class="col-sm-2">
+        <input type="number" [(ngModel)]="port.port" name="port-number-{{ containerIndex }}-{{ i }}" class="form-control">
+      </div>
+
+      <div class="col-sm-1">
+        <button type="button" class="close pull-right" aria-label="Remove" (click)="removePort(i)">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="form-group" *ngIf="availableVolumes.length > 0">
+  <label for="ports">Mount volumes</label>
+
+  <div class="row form-group">
+    <div class="col-sm-4">
+      <select name="available-volumes" class="form-control" [(ngModel)]="selectedVolumeMount">
+        <option value="" disabled selected>Select available</option>
+        <option *ngFor="let volume of availableVolumes" (click)="this.addVolumeMount(volume.name)">{{ volume.name }}</option>
+      </select>
+    </div>
+    <div class="col-sm-2">
+      <button type="button" class="btn btn-sm btn-default" (click)="this.addVolumeMount()">Add</button>
+    </div>
+  </div>
+
+  <div class="row form-group" *ngFor="let mount of container.volumeMounts">
+    <div class="col-sm-2">
+      {{ mount.name }}
+    </div>
+    <div class="col-sm-4">
+      <input type="text" name="volume-path-{{ containerIndex }}-{{ i }}" [(ngModel)]="mount.path" class="form-control" placeholder="/path">
+    </div>
+    <div class="col-sm-1">
+      <button type="button" class="close pull-right" aria-label="Remove" (click)="removeVolumeMount(i)">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/ui/src/app/modules/versions/containers/container-form.html
+++ b/ui/src/app/modules/versions/containers/container-form.html
@@ -1,6 +1,11 @@
 <hr>
 
 <div class="form-group">
+  <label for="name">Name</label>
+  <input type="text" name="container-name-{{ containerIndex }}" [(ngModel)]="container.name" class="form-control">
+</div>
+
+<div class="form-group">
   <label for="image">Image</label>
   <input type="text" name="container-image-{{ containerIndex }}" [(ngModel)]="container.image" class="form-control" placeholder="image:latest">
 </div>

--- a/ui/src/app/modules/versions/containers/container.model.ts
+++ b/ui/src/app/modules/versions/containers/container.model.ts
@@ -1,0 +1,35 @@
+export class Container {
+  public name: string;
+  public image: string;
+  public args: string[];
+  public pullPolicy: string;
+  public ports: ContainerPort[];
+  public volumeMounts: VolumeMount[];
+
+  constructor(props: any = {}) {
+    Object.assign(this, props);
+    this.pullPolicy = this.pullPolicy || "Always";
+    this.args = this.args || [];
+    this.ports = this.ports || [];
+    this.volumeMounts = this.volumeMounts || [];
+  }
+}
+
+export class ContainerPort {
+  public protocol: string;
+  public port: number;
+
+  constructor(props: any = {}) {
+    Object.assign(this, props);
+    this.protocol = this.protocol || "TCP";
+  }
+}
+
+export class VolumeMount {
+  public name: string;
+  public path: string;
+
+  constructor(props: any = {}) {
+    Object.assign(this, props);
+  }
+}

--- a/ui/src/app/modules/versions/create/version-create.component.ts
+++ b/ui/src/app/modules/versions/create/version-create.component.ts
@@ -26,7 +26,7 @@ export class VersionCreateComponent implements OnInit {
     private router: Router,
   ) {
     this.version = new Version({
-      containers: [new Container({args: ["foo", "bar"]})],
+      containers: [new Container()],
       volumes: [],
     });
   }
@@ -48,6 +48,7 @@ export class VersionCreateComponent implements OnInit {
   private createVersion(e: any) {
     e.preventDefault();
     this.version.environment_uuid = this.environment.uuid;
+    console.log(this.version);
 
     this.versionService.createVersion(this.version).subscribe(
       () => (this.onCreateVersion()),

--- a/ui/src/app/modules/versions/create/version-create.component.ts
+++ b/ui/src/app/modules/versions/create/version-create.component.ts
@@ -48,7 +48,6 @@ export class VersionCreateComponent implements OnInit {
   private createVersion(e: any) {
     e.preventDefault();
     this.version.environment_uuid = this.environment.uuid;
-    console.log(this.version);
 
     this.versionService.createVersion(this.version).subscribe(
       () => (this.onCreateVersion()),

--- a/ui/src/app/modules/versions/create/version-create.component.ts
+++ b/ui/src/app/modules/versions/create/version-create.component.ts
@@ -5,7 +5,8 @@ import { Component, EventEmitter, OnInit } from '@angular/core'
 
 import { Environment } from '../../environments/environment.model';
 import { EnvironmentService } from '../../environments/environment.service';
-import { Version, Volume, VolumeMount, ContainerPort } from '../version.model';
+import { Version, Volume } from '../version.model';
+import { Container } from '../containers/container.model';
 import { VersionService } from '../version.service';
 
 @Component({
@@ -17,7 +18,6 @@ export class VersionCreateComponent implements OnInit {
   public version: Version;
   private application: any = {}
   private environment: any = {}
-  private selectedVolumeMount: string;
 
   constructor(
     private versionService: VersionService,
@@ -26,10 +26,8 @@ export class VersionCreateComponent implements OnInit {
     private router: Router,
   ) {
     this.version = new Version({
+      containers: [new Container({args: ["foo", "bar"]})],
       volumes: [],
-      args: [],
-      ports: [],
-      volumeMounts: [],
     });
   }
 
@@ -61,38 +59,19 @@ export class VersionCreateComponent implements OnInit {
     this.router.navigate(['/environments', this.environment.uuid]);
   }
 
+  private addContainer() {
+    this.version.containers.push(new Container());
+  }
+
+  private removeContainer(i: number) {
+    this.version.containers.splice(i, 1);
+  }
+
   private addVolume() {
     this.version.volumes.push(new Volume());
   }
 
   private removeVolume(i: number) {
     this.version.volumes.splice(i, 1);
-  }
-
-  private addPort() {
-    this.version.ports.push(new ContainerPort());
-  }
-
-  private removePort(i: number) {
-    this.version.ports.splice(i, 1);
-  }
-
-  private addArg() {
-    this.version.args.push("");
-  }
-
-  private removeArg(i: number) {
-    this.version.args.splice(i, 1);
-  }
-
-  private addVolumeMount() {
-    let mount = new VolumeMount({
-      name: this.selectedVolumeMount,
-    });
-    this.version.volumeMounts.push(mount);
-  }
-
-  private removeVolumeMount(i: number) {
-    this.version.volumeMounts.splice(i, 1);
   }
 }

--- a/ui/src/app/modules/versions/create/version-create.html
+++ b/ui/src/app/modules/versions/create/version-create.html
@@ -31,94 +31,15 @@
     <div class="row">
         <div class="col-sm-5">
           <h4>Containers</h4>
-
-          <div class="form-group">
-            <label for="image">Image</label>
-            <input type="text" name="image" [(ngModel)]="version.image" class="form-control" placeholder="image:latest">
+          <span class="text-info" role="button" (click)="addContainer()"><i class="fa fa-plus"></i></span>
+          <div *ngFor="let container of version.containers; let i=index">
+            <button type="button" class="close pull-right" aria-label="Remove" (click)="removeContainer(i)">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <container-form [container]="container" [containerIndex]="i" [availableVolumes]="version.volumes"></container-form>
           </div>
-
-          <div class="form-group">
-            <label for="image">Pull policy</label>
-            <select class="form-control" name="pullPolicy" [(ngModel)]="version.pullPolicy">
-              <option value="Always">Always</option>
-              <option value="IfNotPresent">If not present</option>
-              <option value="Never">Never</option>
-            </select>
-          </div>
-
-          <div class="form-group">
-            <label for="args">
-              Args
-              <span class="text-info" role="button" (click)="addArg()"><i class="fa fa-plus"></i></span>
-            </label>
-            <div *ngFor="let arg of version.args; let i=index" class="form-group">
-              <div class="input-group">
-                <input type="text" name="container-argument-{{ i }}" class="form-control" [(ngModel)]="version.args[i]">
-                <span class="input-group-addon">
-                  <span class="text-danger" role="button" (click)="removeArg(i)">&times;</span>
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label for="ports">
-              Ports
-              <span class="text-info" role="button" (click)="addPort()"><i class="fa fa-plus"></i></span>
-            </label>
-            <div *ngFor="let port of version.ports; let i=index">
-              <div class="row form-group">
-                <div class="col-sm-2">
-                  <select name="port-protocol-{{ i }}" [(ngModel)]="port.protocol" class="form-control">
-                    <option value="TCP">TCP</option>
-                    <option value="UDP">UDP</option>
-                  </select>
-                </div>
-
-                <div class="col-sm-2">
-                  <input type="number" [(ngModel)]="port.port" name="port-number-{{ i }}" class="form-control">
-                </div>
-
-                <div class="col-sm-1">
-                  <button type="button" class="close pull-right" aria-label="Remove" (click)="removePort(i)">
-                    <span aria-hidden="true">&times;</span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group" *ngIf="version.volumes.length > 0">
-            <label for="ports">Mount volumes</label>
-
-            <div class="row form-group">
-              <div class="col-sm-4">
-                <select name="available-volumes" class="form-control" [(ngModel)]="selectedVolumeMount">
-                  <option value="" disabled selected>Select available</option>
-                  <option *ngFor="let volume of version.volumes" (click)="this.addVolumeMount(volume.name)">{{ volume.name }}</option>
-                </select>
-              </div>
-              <div class="col-sm-2">
-                <button type="button" class="btn btn-sm btn-default" (click)="this.addVolumeMount()">Add</button>
-              </div>
-            </div>
-
-            <div class="row form-group" *ngFor="let mount of version.volumeMounts">
-              <div class="col-sm-2">
-                {{ mount.name }}
-              </div>
-              <div class="col-sm-4">
-                <input type="text" name="volume-mount-path-{{ i }}" [(ngModel)]="mount.path" class="form-control" placeholder="/path">
-              </div>
-              <div class="col-sm-1">
-                <button type="button" class="close pull-right" aria-label="Remove" (click)="removeVolumeMount(i)">
-                  <span aria-hidden="true">&times;</span>
-                </button>
-              </div>
-            </div>
-          </div>
-
         </div>
+
         <div class="col-sm-4">
           <h4>Volumes</h4>
           <span class="text-info" role="button" (click)="addVolume()"><i class="fa fa-plus"></i></span>

--- a/ui/src/app/modules/versions/version.model.ts
+++ b/ui/src/app/modules/versions/version.model.ts
@@ -1,29 +1,16 @@
+import { Container } from './containers/container.model';
+
 export class Version {
   public uuid: string;
   public name: string;
   public replicas: number;
   public slug: string;
-  public image: string;
-  public args: string[];
-  public ports: ContainerPort[];
-  public pullPolicy: string;
   public environment_uuid: string;
   public volumes: Volume[];
-  public volumeMounts: VolumeMount[];
+  public containers: Container[];
 
   constructor(props: any = {}) {
     Object.assign(this, props);
-    this.pullPolicy = this.pullPolicy || "Always";
-  }
-}
-
-export class ContainerPort {
-  public protocol: string;
-  public port: number;
-
-  constructor(props: any = {}) {
-    Object.assign(this, props);
-    this.protocol = this.protocol || "TCP";
   }
 }
 
@@ -35,13 +22,4 @@ export class Volume {
       Object.assign(this, props);
       this.type = this.type || "temp";
     }
-}
-
-export class VolumeMount {
-  public name: string;
-  public path: string;
-
-  constructor(props: any = {}) {
-    Object.assign(this, props);
-  }
 }

--- a/ui/src/app/modules/versions/version.module.ts
+++ b/ui/src/app/modules/versions/version.module.ts
@@ -9,6 +9,7 @@ import { VersionService } from './version.service';
 import { VersionDetailsComponent } from './details/version-details.component';
 import { VersionCreateComponent } from './create/version-create.component';
 import { VolumeCreateComponent } from './create/volume-create.component';
+import { ContainerFormComponent } from './containers/container-form.component';
 
 const versionRoutes: Routes = [
   {
@@ -33,6 +34,7 @@ const versionRoutes: Routes = [
     VersionDetailsComponent,
     VersionCreateComponent,
     VolumeCreateComponent,
+    ContainerFormComponent,
   ],
   exports: [
     VersionDetailsComponent,

--- a/ui/src/app/modules/versions/version.service.ts
+++ b/ui/src/app/modules/versions/version.service.ts
@@ -24,13 +24,9 @@ export class VersionService {
     let url = this.url + version.environment_uuid + '/versions';
     let data = {
       name: version.name,
-      image: version.image,
       replicas: version.replicas,
       volumes: version.volumes,
-      pullPolicy: version.pullPolicy,
-      args: version.args,
-      ports: version.ports,
-      volumeMounts: version.volumeMounts,
+      containers: version.containers,
     }
 
     return this.http.post(url, data, options)


### PR DESCRIPTION
Adds the ability to specify multiple containers for versions.

The UI needs some major work but it's functional.

![multi-container](https://cloud.githubusercontent.com/assets/4224075/23219487/335da122-f8ed-11e6-9c42-b037163a6a85.gif)


*NOTE*: you will need to manually delete the `image` field from the `versions` table in mysql. I'm creating a task to handle migrations better when things like this come up.