### PR TITLE
Set Version UUID on Deployment Creation and Update

### DIFF
--- a/app/handlers/api/versions.go
+++ b/app/handlers/api/versions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/generationtux/brizo/kube"
 	"github.com/generationtux/brizo/resources"
 	"github.com/go-zoo/bone"
+	"github.com/pborman/uuid"
 )
 
 // VersionIndex provides a listing of all Versions
@@ -144,6 +145,7 @@ func VersionCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	version := resources.Version{
+		UUID:          uuid.New(),
 		Name:          createForm.Name,
 		Slug:          slugify.Slugify(createForm.Name),
 		Containers:    createForm.Containers,

--- a/kube/pods.go
+++ b/kube/pods.go
@@ -37,6 +37,7 @@ func (c *Client) CreateOrUpdateDeployment(deployment *v1beta1.Deployment) error 
 	}
 
 	existingDeployment.Spec = deployment.Spec
+	existingDeployment.ObjectMeta = deployment.ObjectMeta
 
 	_, err = c.k8sClient.Deployments(deployment.Namespace).Update(existingDeployment)
 

--- a/resources/version.go
+++ b/resources/version.go
@@ -219,6 +219,7 @@ func versionDeploymentDefinition(version *Version) *v1beta1.Deployment {
 				"brizoManaged": "true",
 				"appUUID":      version.Environment.Application.UUID,
 				"envUUID":      version.Environment.UUID,
+				"versionUUID":  version.UUID,
 			},
 		},
 		Spec: v1beta1.DeploymentSpec{
@@ -245,6 +246,8 @@ func versionDeploymentDefinition(version *Version) *v1beta1.Deployment {
 			},
 		},
 	}
+
+	fmt.Println(deployment)
 
 	v1beta1.SetObjectDefaults_Deployment(deployment)
 	return deployment

--- a/resources/version.go
+++ b/resources/version.go
@@ -247,8 +247,6 @@ func versionDeploymentDefinition(version *Version) *v1beta1.Deployment {
 		},
 	}
 
-	fmt.Println(deployment)
-
 	v1beta1.SetObjectDefaults_Deployment(deployment)
 	return deployment
 }

--- a/resources/version_test.go
+++ b/resources/version_test.go
@@ -87,7 +87,7 @@ func TestVersionDeploymentDefinition(t *testing.T) {
 	assert.Equal(t, "app", deployment.Spec.Template.Spec.Containers[0].Name)
 	assert.Equal(t, "foo:latest", deployment.Spec.Template.Spec.Containers[0].Image)
 
-	expectDeploymentLabels := map[string]string{"brizoManaged": "true", "appUUID": "app-uuid123", "envUUID": "env-uuid123"}
+	expectDeploymentLabels := map[string]string{"brizoManaged": "true", "appUUID": "app-uuid123", "envUUID": "env-uuid123", "versionUUID": "version-uuid123"}
 	assert.Equal(t, expectDeploymentLabels, deployment.Labels)
 
 	expectSelector := map[string]string{"envUUID": "env-uuid123", "versionUUID": "version-uuid123"}


### PR DESCRIPTION
This PR adds the Version UUID to the ObjectMeta and Spec of each deployment (new or existing).